### PR TITLE
Extract options object

### DIFF
--- a/ada/__init__.py
+++ b/ada/__init__.py
@@ -5,6 +5,7 @@ from .conversation import Conversation
 from .homeassistant import HomeAssistant
 from .hotword import Hotword
 from .microphone import Microphone
+from .options import Options
 from .speech import Speech
 from .voice import Voice
 
@@ -14,13 +15,13 @@ _LOGGER = logging.getLogger(__name__)
 class Ada:
     """Hey Ada assistant."""
 
-    def __init__(self):
+    def __init__(self, options: Options):
         """Initialize ada."""
-        self.homeassistant = HomeAssistant()
+        self.homeassistant = HomeAssistant(options)
         self.hotword: Hotword = Hotword()
         self.speech: Speech = Speech(self.homeassistant)
         self.conversation: Conversation = Conversation(self.homeassistant)
-        self.voice: Voice = Voice(self.homeassistant)
+        self.voice: Voice = Voice(self.homeassistant, options)
         self.microphone: Microphone = Microphone(
             self.hotword.frame_length, self.hotword.sample_rate
         )

--- a/ada/__main__.py
+++ b/ada/__main__.py
@@ -25,6 +25,8 @@ def main():
     options = Options(
         hass_api_url="http://hassio/homeassistant/api",
         hass_token=os.environ.get("HASSIO_TOKEN"),
+        stt_platform="cloud",
+        tts_platform="cloud",
     )
 
     ada = Ada(options)

--- a/ada/__main__.py
+++ b/ada/__main__.py
@@ -1,7 +1,9 @@
 """Ada assistant."""
+import os
 import logging
 
-from ada import Ada
+from . import Ada
+from .options import Options
 
 
 def init_logger():
@@ -20,7 +22,12 @@ def main():
     """Run Application."""
     init_logger()
 
-    ada = Ada()
+    options = Options(
+        hass_api_url="http://hassio/homeassistant/api",
+        hass_token=os.environ.get("HASSIO_TOKEN"),
+    )
+
+    ada = Ada(options)
     ada.run()
 
 

--- a/ada/homeassistant.py
+++ b/ada/homeassistant.py
@@ -28,7 +28,9 @@ class HomeAssistant:
 
         _LOGGER.info("Sending audio stream to Home Assistant STT")
         req = requests.post(
-            f"{self.options.hass_api_url}/stt/cloud", data=data_gen, headers=headers
+            f"{self.options.hass_api_url}/stt/{self.options.stt_platform}",
+            data=data_gen,
+            headers=headers,
         )
 
         if req.status_code != 200:
@@ -53,7 +55,7 @@ class HomeAssistant:
         _LOGGER.info("Send text to Home Assistant TTS")
         req = requests.post(
             f"{self.options.hass_api_url}/tts_get_url",
-            json={"platform": "cloud", "message": text},
+            json={"platform": self.options.tts_platform, "message": text},
             headers=self.headers,
         )
 

--- a/ada/options.py
+++ b/ada/options.py
@@ -2,4 +2,6 @@
 from collections import namedtuple
 
 
-Options = namedtuple("Options", ["hass_api_url", "hass_token"])
+Options = namedtuple(
+    "Options", ["hass_api_url", "hass_token", "stt_platform", "tts_platform"]
+)

--- a/ada/options.py
+++ b/ada/options.py
@@ -1,0 +1,5 @@
+"""Helper to hold options for Ada."""
+from collections import namedtuple
+
+
+Options = namedtuple("Options", ["hass_api_url", "hass_token"])

--- a/ada/voice.py
+++ b/ada/voice.py
@@ -1,9 +1,9 @@
 """Voice of Ada."""
 import logging
-import os
 import subprocess
 
 from .homeassistant import HomeAssistant
+from .options import Options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,12 +11,12 @@ _LOGGER = logging.getLogger(__name__)
 class Voice:
     """Voice of ada."""
 
-    def __init__(self, homeassistant: HomeAssistant) -> None:
+    def __init__(self, homeassistant: HomeAssistant, options: Options) -> None:
         """Initialize Voice output processing."""
         self.homeassistant: HomeAssistant = homeassistant
+        self.options: Options = options
 
-    @staticmethod
-    def _play(audio_url: str) -> bool:
+    def _play(self, audio_url: str) -> bool:
         """Play Audio file from buffer."""
         play = subprocess.Popen(
             [
@@ -24,7 +24,7 @@ class Voice:
                 "-quiet",
                 "-prefer-ipv4",
                 "-http-header-fields",
-                f"Authorization: Bearer {os.environ.get('HASSIO_TOKEN')}",
+                f"Authorization: Bearer {self.options.hass_token}",
                 audio_url,
             ],
             stdin=None,
@@ -45,4 +45,4 @@ class Voice:
         filename = url["url"].split("/")[-1]
         _LOGGER.info("TTS is available as %s", filename)
 
-        return self._play(f"{self.homeassistant.url}/tts_proxy/{filename}")
+        return self._play(f"{self.options.hass_api_url}/tts_proxy/{filename}")

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,13 @@ setup(
     keywords=["voice", "home-assistant", "personal"],
     zip_safe=False,
     platforms="any",
-    packages=["ada",],
+    packages=["ada"],
+    install_requires=[
+        "requests",
+        "numpy",
+        "webrtcvad",
+        "pyaudio",
+        "importlib_metadata",
+    ],
     include_package_data=True,
 )


### PR DESCRIPTION
Extract an options object. For now still hardcode it with original values in `__main__.py`. 

Instead of requiring porcupine path to be passed in, resolve it from the pvporcupine package. @pvizeli why can't we import pvporcupine directly? Can we document that somewhere.

Will leave it up to @pvizeli how we want to fill that data in there, all OS vars? Command line args?

Fix #6 