### PR TITLE
setup requires wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
         "importlib_metadata",
         "click"
     ],
+    setup_requires=['wheel'],
     include_package_data=True,
 )


### PR DESCRIPTION
When installing ada into a virtual environment, observed the following error:
```
Building wheels for collected packages: ada
  Running setup.py bdist_wheel for ada ... error
  Complete output from command /home/pi/ada_venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-req-build-2qc_p13f/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-zff943an --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
```
It installs correctly from my fork with this line in the setup.py file.