### PR TITLE
Fix unsupported architecture error on arm64

### DIFF
--- a/ada/hotword.py
+++ b/ada/hotword.py
@@ -102,7 +102,7 @@ class PorcupineLoader:
 
         if machine == "x86_64":
             return lib_path / "resources/keyword_files/linux/hey pico_linux.ppn"
-        if machine in ("armv7l", "armv6l"):
+        if machine in ("armv7l", "aarch64", "armv6l"):
             return (
                 lib_path
                 / "resources/keyword_files/raspberrypi/hey pico_raspberrypi.ppn"


### PR DESCRIPTION
This is a followup on https://github.com/home-assistant/ada/pull/13, there was one more place where the architecture has been tested against. Without this fix, the program crashes on arm64 with:
```
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] done.
[services.d] starting services
[services.d] done.
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/src/ada/ada/__main__.py", line 47, in <module>
    main()
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/src/ada/ada/__main__.py", line 41, in main
    ada = Ada(options)
  File "/usr/src/ada/ada/__init__.py", line 21, in __init__
    self.hotword: Hotword = Hotword()
  File "/usr/src/ada/ada/hotword.py", line 21, in __init__
    self.porcupine = loader.load()
  File "/usr/src/ada/ada/hotword.py", line 75, in load
    keyword_file_path=str(self._keyword_file_path(lib_path)),
  File "/usr/src/ada/ada/hotword.py", line 111, in _keyword_file_path
    raise RuntimeError("Architecture is not supported by Hotword")
RuntimeError: Architecture is not supported by Hotword
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```

Fixes https://github.com/home-assistant/ada/issues/16